### PR TITLE
refactor: update mandatory plugin versions to 'latest'

### DIFF
--- a/pkg/plugins/init.go
+++ b/pkg/plugins/init.go
@@ -66,15 +66,15 @@ func connectPlugin(name, path string) (Plugin, *plugin.Client, error) {
 func Init(cfg *config.Config) (loadedPlugin map[string]Plugin, plugins []shared_models.Plugin, actionPlugins []shared_models.Plugin, endpointPlugins []shared_models.Plugin) {
 	// Define mandatory plugins
 	mandatoryPlugins := []config.PluginConfig{
-		{Name: "collect_data", Version: "v1.3.2"},
-		{Name: "actions_check", Version: "v1.4.1"},
-		{Name: "pattern_check", Version: "v1.4.1"},
-		{Name: "log", Version: "v1.4.1"},
-		{Name: "wait", Version: "v1.4.1"},
-		{Name: "interaction", Version: "v1.4.1"},
-		{Name: "ping", Version: "v1.5.1"},
-		{Name: "port_checker", Version: "v1.4.1"},
-		{Name: "step_analysis", Version: "v1.2.1"},
+		{Name: "collect_data", Version: "latest"},
+		{Name: "actions_check", Version: "latest"},
+		{Name: "pattern_check", Version: "latest"},
+		{Name: "log", Version: "latest"},
+		{Name: "wait", Version: "latest"},
+		{Name: "interaction", Version: "latest"},
+		{Name: "ping", Version: "latest"},
+		{Name: "port_checker", Version: "latest"},
+		{Name: "step_analysis", Version: "latest"},
 	}
 
 	// Merge mandatory plugins with config plugins, handling conflicts


### PR DESCRIPTION
This pull request updates the mandatory plugins in the `Init` function to always use the latest version instead of specific version numbers. This change simplifies version management and ensures plugins stay up-to-date.

Plugin version updates:

* [`pkg/plugins/init.go`](diffhunk://#diff-c5d9e18b3fdeac5f10e03955ea8eab1088f6b2cc9803a28bd25d0b962a2ca676L69-R77): Changed the `Version` field for all mandatory plugins (`collect_data`, `actions_check`, `pattern_check`, `log`, `wait`, `interaction`, `ping`, `port_checker`, and `step_analysis`) from specific versions (e.g., `v1.3.2`) to `latest`.