### PR TITLE
feat: enhance plugin download logic to remove existing latest plugins

### DIFF
--- a/pkg/plugins/download.go
+++ b/pkg/plugins/download.go
@@ -31,9 +31,18 @@ func DownloadPlugins(pluginRepos []config.PluginConfig, buildDir string, pluginD
 
 		// Check if the plugin already exists
 		if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
-			log.Info("Plugin already exists: ", pluginPath)
-			pluginPaths[plugin.Name] = pluginPath
-			continue
+
+			// if plugin version is latest, delete the existing plugin if it exists
+			if plugin.Version == "latest" {
+				if err := os.RemoveAll(pluginPath); err != nil {
+					return nil, fmt.Errorf("failed to remove existing plugin %s: %v", plugin.Name, err)
+				}
+				log.Info("Removed existing latest plugin: ", pluginPath)
+			} else {
+				log.Info("Plugin already exists: ", pluginPath)
+				pluginPaths[plugin.Name] = pluginPath
+				continue
+			}
 		}
 
 		// Create the plugin file


### PR DESCRIPTION
This pull request introduces a change to the plugin download logic in the `pkg/plugins/download.go` file. Specifically, it adds functionality to ensure that when a plugin version is specified as "latest," any existing version of the plugin is removed before downloading the new version.

Key change:

* [`pkg/plugins/download.go`](diffhunk://#diff-8df17c2ebca1c6d92a69745e5ec0a085f98803c87a5a7faafc446f17039dd826R34-R46): Updated the `DownloadPlugins` function to check if the plugin version is "latest" and, if so, remove the existing plugin directory before proceeding with the download. This ensures that the latest version of the plugin is always fetched.