### PR TITLE
fix: update execution model references to use the correct package

### DIFF
--- a/pkg/executions/interaction_waiting.go
+++ b/pkg/executions/interaction_waiting.go
@@ -5,19 +5,19 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/v1Flows/exFlow/services/backend/pkg/models"
 	"github.com/v1Flows/runner/config"
 	"github.com/v1Flows/runner/pkg/platform"
-	shared_models "github.com/v1Flows/shared-library/pkg/models"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func SetToInteractionRequired(cfg *config.Config, execution shared_models.Executions) {
+func SetToInteractionRequired(cfg *config.Config, execution models.Executions) {
 	execution.Status = "interactionWaiting"
 	InteractionWaiting(cfg, execution)
 }
 
-func InteractionWaiting(cfg *config.Config, execution shared_models.Executions) {
+func InteractionWaiting(cfg *config.Config, execution models.Executions) {
 	payloadBuf := new(bytes.Buffer)
 	json.NewEncoder(payloadBuf).Encode(execution)
 

--- a/pkg/executions/pause.go
+++ b/pkg/executions/pause.go
@@ -5,19 +5,19 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/v1Flows/exFlow/services/backend/pkg/models"
 	"github.com/v1Flows/runner/config"
 	"github.com/v1Flows/runner/pkg/platform"
-	shared_models "github.com/v1Flows/shared-library/pkg/models"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func SetToPaused(cfg *config.Config, execution shared_models.Executions) {
+func SetToPaused(cfg *config.Config, execution models.Executions) {
 	execution.Status = "paused"
 	Pause(cfg, execution)
 }
 
-func Pause(cfg *config.Config, execution shared_models.Executions) {
+func Pause(cfg *config.Config, execution models.Executions) {
 	payloadBuf := new(bytes.Buffer)
 	json.NewEncoder(payloadBuf).Encode(execution)
 

--- a/pkg/executions/running.go
+++ b/pkg/executions/running.go
@@ -5,19 +5,19 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/v1Flows/exFlow/services/backend/pkg/models"
 	"github.com/v1Flows/runner/config"
 	"github.com/v1Flows/runner/pkg/platform"
-	shared_models "github.com/v1Flows/shared-library/pkg/models"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func SetToRunning(cfg *config.Config, execution shared_models.Executions) {
+func SetToRunning(cfg *config.Config, execution models.Executions) {
 	execution.Status = "running"
 	Running(cfg, execution)
 }
 
-func Running(cfg *config.Config, execution shared_models.Executions) {
+func Running(cfg *config.Config, execution models.Executions) {
 	payloadBuf := new(bytes.Buffer)
 	json.NewEncoder(payloadBuf).Encode(execution)
 


### PR DESCRIPTION
This pull request updates the way the `Executions` model is imported and used in the runner package. Instead of using the shared library's model, it now directly imports the model from the backend service, ensuring consistency with backend data structures. The changes affect the handling of execution status transitions in several files.

Model import update:

* Changed import in `pkg/executions/interaction_waiting.go`, `pkg/executions/pause.go`, and `pkg/executions/running.go` to use `models.Executions` from `exFlow/services/backend/pkg/models` instead of `shared_models.Executions` from the shared library. [[1]](diffhunk://#diff-2762834328806ed094b01e7fac82844d2bcba34b060ba425c0349d7995e87206R8-R20) [[2]](diffhunk://#diff-3a7446834ab02b6c2249ac33a420f593853e7c190c7dd0ba9f487f34b3daf3a4R8-R20) [[3]](diffhunk://#diff-cd4c0157beae0b40b44dbaa333913fb1d68e84e762b3777b502121ede611831bR8-R20)

Function signature and usage update:

* Updated function signatures and usages in all three files to use `models.Executions` for the `execution` parameter, ensuring type consistency throughout the runner package. [[1]](diffhunk://#diff-2762834328806ed094b01e7fac82844d2bcba34b060ba425c0349d7995e87206R8-R20) [[2]](diffhunk://#diff-3a7446834ab02b6c2249ac33a420f593853e7c190c7dd0ba9f487f34b3daf3a4R8-R20) [[3]](diffhunk://#diff-cd4c0157beae0b40b44dbaa333913fb1d68e84e762b3777b502121ede611831bR8-R20)