### PR TITLE
Refactor project structure and update references from v1Flows to Just…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We welcome contributions to the Runner project! By contributing, you help make t
 1. Fork the repository on GitHub.
 2. Clone your forked repository:
     ```sh
-    git clone git@github.com:v1Flows/runner.git
+    git clone git@github.com:JustLABv1/runner.git
     cd runner
     ```
 3. Create a new branch for your changes:

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ api_endpoint:
 ```
 
 ## Plugins
-The runner can be extended by integrating plugins following a specific schema. A list of available plugins can be found [here](https://github.com/v1Flows/runner-plugins).
+The runner can be extended by integrating plugins following a specific schema. A list of available plugins can be found [here](https://github.com/JustLABv1/runner-plugins).
 
-To develop your own plugin you can start right away with this [template](https://github.com/v1Flows/runner-plugins/tree/develop/template)
+To develop your own plugin you can start right away with this [template](https://github.com/JustLABv1/runner-plugins/tree/develop/template)
 
 ## Modes
 
@@ -91,4 +91,4 @@ We welcome contributions to this project! To contribute, follow these steps:
 5. Open a pull request on GitHub.
 
 ## License
-This project is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3. See the [LICENSE](https://github.com/v1Flows/runner/blob/main/LICENSE) file for details.
+This project is licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3. See the [LICENSE](https://github.com/JustLABv1/runner/blob/main/LICENSE) file for details.

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -8,15 +8,15 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/internal/api"
+	internal_executions "github.com/JustLABv1/runner/internal/executions"
+	"github.com/JustLABv1/runner/internal/runner"
+	"github.com/JustLABv1/runner/internal/worker"
+	"github.com/JustLABv1/runner/pkg/plugins"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/internal/api"
-	internal_executions "github.com/v1Flows/runner/internal/executions"
-	"github.com/v1Flows/runner/internal/runner"
-	"github.com/v1Flows/runner/internal/worker"
-	"github.com/v1Flows/runner/pkg/plugins"
 
 	"github.com/alecthomas/kingpin/v2"
 )
@@ -48,7 +48,7 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
-	log.Info("Starting v1Flows Runner. Version: ", version)
+	log.Info("Starting JustLAB Runner. Version: ", version)
 
 	log.Info("Loading config")
 	configManager := config.GetInstance()
@@ -72,7 +72,7 @@ func main() {
 	router := gin.Default()
 
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"https://exflow.org", "https://alertflow.org", "http://localhost:8080", "http://localhost:3000", "http://localhost:4000", "http://localhost:8081"},
+		AllowOrigins:     []string{"https://justflow.app", "http://localhost:8080", "http://localhost:3000", "http://localhost:4000", "http://localhost:8081"},
 		AllowMethods:     []string{"GET", "HEAD", "POST", "PUT", "OPTIONS", "DELETE"},
 		AllowHeaders:     []string{"Origin", "Authorization", "X-Requested-With", "Content-Type"},
 		ExposeHeaders:    []string{"Content-Length"},

--- a/config/config.go
+++ b/config/config.go
@@ -178,28 +178,28 @@ func (cm *ConfigurationManager) GetConfig() *Config {
 	return cm.config
 }
 
-// UpdateRunnerID updates the runner ID in the configuration for both Alertflow and ExFlow
+// UpdateRunnerID updates the runner ID in the configuration for JustFlow
 func (cm *ConfigurationManager) UpdateRunnerID(id string) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config.JustFlow.RunnerID = id
 }
 
-// UpdateRunnerApiKey updates the runner api_key in the configuration for both Alertflow and ExFlow
+// UpdateRunnerApiKey updates the runner api_key in the configuration for JustFlow
 func (cm *ConfigurationManager) UpdateRunnerApiKey(apiKey string) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config.JustFlow.APIKey = apiKey
 }
 
-// GetRunnerIDs returns the current runner IDs for both Alertflow and ExFlow
+// GetRunnerIDs returns the current runner IDs for JustFlow
 func (cm *ConfigurationManager) GetRunnerID() string {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 	return cm.config.JustFlow.RunnerID
 }
 
-// GetRunnerIDs returns the current runner apiKey for both Alertflow and ExFlow
+// GetRunnerIDs returns the current runner apiKey for JustFlow
 func (cm *ConfigurationManager) GetRunnerApiKey() string {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,8 +3,8 @@
 log_level: info
 mode: master
 
-exflow:
-  url: https://exflow.org
+justflow:
+  url: https://justflow.app
   runner_id: null
   api_key: null
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/v1Flows/runner
+module github.com/JustLABv1/runner
 
 go 1.24.0
 
@@ -10,7 +10,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/v1Flows/alertFlow/services/backend v0.0.0-20250317112742-7a11f04dd445
 )
 
 require (
@@ -76,7 +75,6 @@ require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.11.0
 	github.com/spf13/viper v1.21.0
-	github.com/v1Flows/exFlow/services/backend v0.0.0-20250904092110-86db1f89ca20
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -142,10 +142,6 @@ github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/uptrace/bun v1.2.16 h1:QlObi6ZIK5Ao7kAALnh91HWYNZUBbVwye52fmlQM9kc=
 github.com/uptrace/bun v1.2.16/go.mod h1:jMoNg2n56ckaawi/O/J92BHaECmrz6IRjuMWqlMaMTM=
-github.com/v1Flows/alertFlow/services/backend v0.0.0-20250317112742-7a11f04dd445 h1:o1WaAweRrGc6Yz4G3DTE9cr6sFul1TJ9k71yIbECQYQ=
-github.com/v1Flows/alertFlow/services/backend v0.0.0-20250317112742-7a11f04dd445/go.mod h1:wN72OUmADQ95eNYyiYM4oa6FOnvoCBRljzsGQGdvaIA=
-github.com/v1Flows/exFlow/services/backend v0.0.0-20250904092110-86db1f89ca20 h1:yfee6np8MyaFQv8JKXbNsM7CMZ/Qykg9PDYg4Cmz+Uk=
-github.com/v1Flows/exFlow/services/backend v0.0.0-20250904092110-86db1f89ca20/go.mod h1:FDHugsWJJxP5p0baCAd7YQ375DmD0zQchxZKLASJ3Cc=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/actions/check_conditions.go
+++ b/internal/actions/check_conditions.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/executions"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/executions"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/JustLABv1/justflow/services/backend/functions/httperror"
-	"github.com/v1Flows/runner/internal/token"
+	"github.com/JustLABv1/runner/internal/token"
 
 	"github.com/gin-gonic/gin"
 )

--- a/internal/api/endpoint.go
+++ b/internal/api/endpoint.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/executions"
+	"github.com/JustLABv1/runner/pkg/plugins"
 	"github.com/google/uuid"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/executions"
-	"github.com/v1Flows/runner/pkg/plugins"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"

--- a/internal/api/ready.go
+++ b/internal/api/ready.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"github.com/JustLABv1/runner/config"
 	"github.com/gin-gonic/gin"
-	"github.com/v1Flows/runner/config"
 )
 
 func ReadyEndpoint(cfg *config.Config, router *gin.Engine) {

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,0 +1,107 @@
+package cleanup
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/executions"
+	log "github.com/sirupsen/logrus"
+)
+
+func PerformWorkspaceCleanup(cfg *config.Config, execution models.Executions, flow models.Flows) error {
+	if flow.AlwaysCleanupWorkspace {
+		cleanupStep, err := createCleanupStep(cfg, execution)
+		if err != nil {
+			return err
+		}
+
+		err = os.RemoveAll(fmt.Sprintf("%s/%s", cfg.WorkspaceDir, execution.ID))
+		if err != nil {
+			log.Error("Error deleting workspace dir: ", err)
+
+			err = executions.UpdateStep(nil, execution.ID.String(), models.ExecutionSteps{
+				ID: cleanupStep.ID,
+				Messages: []models.Message{
+					{
+						Title: "Cleanup Workspace",
+						Lines: []models.Line{
+							{
+								Content:   "Failed to delete workspace dir: " + err.Error(),
+								Timestamp: time.Now(),
+								Color:     "danger",
+							},
+						},
+					},
+				},
+				Status:     "error",
+				RunnerID:   execution.RunnerID,
+				FinishedAt: time.Now(),
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		err = executions.UpdateStep(nil, execution.ID.String(), models.ExecutionSteps{
+			ID: cleanupStep.ID,
+			Messages: []models.Message{
+				{
+					Title: "Cleanup Workspace",
+					Lines: []models.Line{
+						{
+							Content:   "Workspace directory deleted successfully.",
+							Timestamp: time.Now(),
+							Color:     "success",
+						},
+					},
+				},
+			},
+			Status:     "success",
+			RunnerID:   execution.RunnerID,
+			FinishedAt: time.Now(),
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func createCleanupStep(cfg *config.Config, execution models.Executions) (models.ExecutionSteps, error) {
+	cleanupStep := models.ExecutionSteps{
+		Action: models.Action{
+			Plugin: "cleanup",
+			Params: []models.Params{},
+		},
+		Messages: []models.Message{
+			{
+				Title: "Cleanup Workspace",
+				Lines: []models.Line{
+					{
+						Content:   "Perform workspace cleanup. Path: " + cfg.WorkspaceDir + "/" + execution.ID.String(),
+						Timestamp: time.Now(),
+						Color:     "success",
+					},
+				},
+			},
+		},
+		Status:    "running",
+		RunnerID:  execution.RunnerID,
+		CreatedAt: time.Now(),
+	}
+
+	stepID, err := executions.SendStep(cfg, execution, cleanupStep)
+	if err != nil {
+		return models.ExecutionSteps{}, err
+	}
+
+	cleanupStep.ID = stepID.ID
+
+	return cleanupStep, nil
+}

--- a/internal/executions/cancel_remaining_steps.go
+++ b/internal/executions/cancel_remaining_steps.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/pkg/executions"
 	log "github.com/sirupsen/logrus"
-	"github.com/v1Flows/runner/pkg/executions"
 )
 
 func cancelRemainingSteps(executionID string) error {

--- a/internal/executions/failure_pipeline.go
+++ b/internal/executions/failure_pipeline.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/executions"
-	"github.com/v1Flows/runner/pkg/plugins"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/executions"
+	"github.com/JustLABv1/runner/pkg/plugins"
 )
 
 func startFailurePipeline(cfg *config.Config, workspace string, actions []models.Action, loadedPlugins map[string]plugins.Plugin, flow models.Flows, flowBytes []byte, alert models.Alerts, steps []models.ExecutionSteps, failedStep models.ExecutionSteps, execution models.Executions) error {

--- a/internal/executions/get_pending_executions.go
+++ b/internal/executions/get_pending_executions.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	jf_models "github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/pkg/platform"
-	"github.com/v1Flows/runner/pkg/plugins"
+	"github.com/JustLABv1/runner/pkg/platform"
+	"github.com/JustLABv1/runner/pkg/plugins"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/executions/process_step.go
+++ b/internal/executions/process_step.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	internal_actions "github.com/v1Flows/runner/internal/actions"
-	"github.com/v1Flows/runner/internal/common"
-	"github.com/v1Flows/runner/pkg/executions"
-	"github.com/v1Flows/runner/pkg/plugins"
+	"github.com/JustLABv1/runner/config"
+	internal_actions "github.com/JustLABv1/runner/internal/actions"
+	"github.com/JustLABv1/runner/internal/common"
+	"github.com/JustLABv1/runner/pkg/executions"
+	"github.com/JustLABv1/runner/pkg/plugins"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/executions/send_flow_action_steps.go
+++ b/internal/executions/send_flow_action_steps.go
@@ -2,11 +2,11 @@ package internal_executions
 
 import (
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/executions"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/executions"
 )
 
-// SendFlowActionSteps sends all active flow actions to alertflow
+// SendFlowActionSteps sends all active flow actions to justflow
 func sendFlowActionSteps(cfg *config.Config, execution models.Executions, flow models.Flows) (stepsWithIDs []models.ExecutionSteps, err error) {
 	for _, action := range flow.Actions {
 		if !action.Active {

--- a/internal/executions/start_processing.go
+++ b/internal/executions/start_processing.go
@@ -5,13 +5,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/JustLABv1/justflow/services/backend/pkg/models"
 	jf_models "github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/internal/cleanup"
+	internal_justflow "github.com/JustLABv1/runner/internal/justflow"
+	"github.com/JustLABv1/runner/internal/runner"
+	"github.com/JustLABv1/runner/pkg/executions"
+	"github.com/JustLABv1/runner/pkg/plugins"
 	"github.com/google/uuid"
-	"github.com/v1Flows/runner/config"
-	internal_justflow "github.com/v1Flows/runner/internal/justflow"
-	"github.com/v1Flows/runner/internal/runner"
-	"github.com/v1Flows/runner/pkg/executions"
-	"github.com/v1Flows/runner/pkg/plugins"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -55,6 +57,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 	err = executions.UpdateExecution(nil, execution)
 	if err != nil {
+		postProcessing(cfg, execution, jf_models.Flows{})
 		executions.EndWithError(nil, execution)
 		// Stop heartbeats and finish processing
 		close(doneHeartbeat)
@@ -69,6 +72,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 	var initialSteps []jf_models.ExecutionSteps
 	initialSteps, err = internal_justflow.SendInitialSteps(cfg, actions, execution)
 	if err != nil {
+		postProcessing(cfg, execution, jf_models.Flows{})
 		executions.EndWithError(nil, execution)
 		// Stop heartbeats and finish processing
 		close(doneHeartbeat)
@@ -87,6 +91,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 				log.Error("Error processing initial step: ", err)
 				// cancel remaining steps
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				// end execution
 				executions.EndWithError(nil, execution)
 				// Stop heartbeats and finish processing
@@ -97,6 +102,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 			if canceled {
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				executions.EndCanceled(nil, execution)
 				// Stop heartbeats and finish processing
 				close(doneHeartbeat)
@@ -109,6 +115,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 			} else if flow.ID == uuid.Nil {
 				log.Error("Error parsing flow")
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				executions.EndWithError(nil, execution)
 				// Stop heartbeats and finish processing
 				close(doneHeartbeat)
@@ -125,6 +132,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 			} else if flow.Type == "alert" && alert.ID == uuid.Nil {
 				log.Error("Error parsing alert")
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				executions.EndWithError(nil, execution)
 				// Stop heartbeats and finish processing
 				close(doneHeartbeat)
@@ -134,6 +142,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 			if res.Data["status"] == "noPatternMatch" {
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				executions.EndNoPatternMatch(nil, execution)
 				finishProcessing(cfg, execution, flow)
 				return
@@ -141,6 +150,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 			if res.Data["status"] == "canceled" {
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				executions.EndCanceled(nil, execution)
 				// Stop heartbeats and finish processing
 				close(doneHeartbeat)
@@ -150,6 +160,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 			if !success {
 				cancelRemainingSteps(execution.ID.String())
+				postProcessing(cfg, execution, flow)
 				executions.EndWithError(nil, execution)
 				// Stop heartbeats and finish processing
 				close(doneHeartbeat)
@@ -159,9 +170,10 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 		}
 	}
 
-	// send flow actions as steps to alertflow
+	// send flow actions as steps to justflow
 	flowActionStepsWithIDs, err := sendFlowActionSteps(cfg, execution, flow)
 	if err != nil {
+		postProcessing(cfg, execution, flow)
 		executions.EndWithError(nil, execution)
 		// Stop heartbeats and finish processing
 		close(doneHeartbeat)
@@ -182,6 +194,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 					if flow.FailurePipelineID != "" || step.Action.FailurePipelineID != "" {
 						err = startFailurePipeline(cfg, workspace, actions, loadedPlugins, flow, flowBytes, alert, flowActionStepsWithIDs, step, execution)
 						if err != nil {
+							postProcessing(cfg, execution, flow)
 							// end execution with recovered status
 							executions.EndWithError(nil, execution)
 							// Stop heartbeats and finish processing
@@ -191,6 +204,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 						}
 					}
 
+					postProcessing(cfg, execution, flow)
 					// end execution
 					executions.EndWithError(nil, execution)
 					// Stop heartbeats and finish processing
@@ -201,6 +215,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 				if res.Data["status"] == "noPatternMatch" {
 					cancelRemainingSteps(execution.ID.String())
+					postProcessing(cfg, execution, flow)
 					executions.EndNoPatternMatch(nil, execution)
 					// Stop heartbeats and finish processing
 					close(doneHeartbeat)
@@ -210,6 +225,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 				if res.Data["status"] == "canceled" {
 					cancelRemainingSteps(execution.ID.String())
+					postProcessing(cfg, execution, flow)
 					executions.EndCanceled(nil, execution)
 					// Stop heartbeats and finish processing
 					close(doneHeartbeat)
@@ -219,6 +235,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 
 				if canceled {
 					cancelRemainingSteps(execution.ID.String())
+					postProcessing(cfg, execution, flow)
 					executions.EndCanceled(nil, execution)
 					// Stop heartbeats and finish processing
 					close(doneHeartbeat)
@@ -233,6 +250,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 					if flow.FailurePipelineID != "" || step.Action.FailurePipelineID != "" {
 						err = startFailurePipeline(cfg, workspace, actions, loadedPlugins, flow, flowBytes, alert, flowActionStepsWithIDs, step, execution)
 						if err != nil {
+							postProcessing(cfg, execution, flow)
 							executions.EndWithError(nil, execution)
 							// Stop heartbeats and finish processing
 							close(doneHeartbeat)
@@ -240,6 +258,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 							return
 						}
 
+						postProcessing(cfg, execution, flow)
 						// end execution with recovered status
 						executions.EndWithRecovered(nil, execution)
 						// Stop heartbeats and finish processing
@@ -248,6 +267,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 						return
 					}
 
+					postProcessing(cfg, execution, flow)
 					executions.EndWithError(nil, execution)
 					// Stop heartbeats and finish processing
 					close(doneHeartbeat)
@@ -304,6 +324,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 		}
 
 		if failedSteps > 0 {
+			postProcessing(cfg, execution, flow)
 			executions.EndWithError(nil, execution)
 			// Stop heartbeats and finish processing
 			close(doneHeartbeat)
@@ -312,6 +333,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 		}
 
 		if canceledSteps > 0 {
+			postProcessing(cfg, execution, flow)
 			executions.EndCanceled(nil, execution)
 			// Stop heartbeats and finish processing
 			close(doneHeartbeat)
@@ -320,6 +342,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 		}
 
 		if noPatternMatchSteps > 0 {
+			postProcessing(cfg, execution, flow)
 			executions.EndNoPatternMatch(nil, execution)
 			// Stop heartbeats and finish processing
 			close(doneHeartbeat)
@@ -328,6 +351,7 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 		}
 	}
 
+	postProcessing(cfg, execution, flow)
 	executions.EndSuccess(nil, execution)
 
 	// Stop heartbeats and finish processing
@@ -335,11 +359,13 @@ func startProcessing(actions []jf_models.Action, loadedPlugins map[string]plugin
 	finishProcessing(cfg, execution, flow)
 }
 
-func finishProcessing(cfg *config.Config, execution jf_models.Executions, flow jf_models.Flows) {
-	err := os.RemoveAll(fmt.Sprintf("%s/%s", cfg.WorkspaceDir, execution.ID))
+func postProcessing(cfg *config.Config, execution models.Executions, flow models.Flows) {
+	err := cleanup.PerformWorkspaceCleanup(cfg, execution, flow)
 	if err != nil {
-		log.Error("Error deleting workspace dir: ", err)
+		log.Error("Error during workspace cleanup: ", err)
 	}
+}
 
+func finishProcessing(cfg *config.Config, execution jf_models.Executions, flow jf_models.Flows) {
 	runner.Busy(false)
 }

--- a/internal/justflow/send_initial_steps.go
+++ b/internal/justflow/send_initial_steps.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/executions"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/executions"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/runner/busy.go
+++ b/internal/runner/busy.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/v1Flows/alertFlow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/runner/register.go
+++ b/internal/runner/register.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/internal/token"
+	"github.com/JustLABv1/runner/pkg/platform"
 	"github.com/google/uuid"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/internal/token"
-	"github.com/v1Flows/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/runner/send_heatbeat.go
+++ b/internal/runner/send_heatbeat.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -2,8 +2,8 @@ package worker
 
 import (
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	internal_executions "github.com/v1Flows/runner/internal/executions"
-	"github.com/v1Flows/runner/pkg/plugins"
+	internal_executions "github.com/JustLABv1/runner/internal/executions"
+	"github.com/JustLABv1/runner/pkg/plugins"
 )
 
 func StartWorker(actions []models.Action, loadedPlugins map[string]plugins.Plugin) {

--- a/pkg/alerts/get_data.go
+++ b/pkg/alerts/get_data.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	internal_models "github.com/v1Flows/runner/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	internal_models "github.com/JustLABv1/runner/pkg/models"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/alerts/get_grouped_alerts.go
+++ b/pkg/alerts/get_grouped_alerts.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	internal_models "github.com/v1Flows/runner/pkg/models"
+	"github.com/JustLABv1/runner/config"
+	internal_models "github.com/JustLABv1/runner/pkg/models"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/alerts/send_alert.go
+++ b/pkg/alerts/send_alert.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
+	"github.com/JustLABv1/runner/config"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/alerts/update_alert.go
+++ b/pkg/alerts/update_alert.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
+	"github.com/JustLABv1/runner/config"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/end.go
+++ b/pkg/executions/end.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/internal/runner"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/internal/runner"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/get.go
+++ b/pkg/executions/get.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/get_step.go
+++ b/pkg/executions/get_step.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	internal_models "github.com/v1Flows/runner/pkg/models"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	internal_models "github.com/JustLABv1/runner/pkg/models"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/get_steps.go
+++ b/pkg/executions/get_steps.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	internal_models "github.com/v1Flows/runner/pkg/models"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	internal_models "github.com/JustLABv1/runner/pkg/models"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/interaction_waiting.go
+++ b/pkg/executions/interaction_waiting.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/pause.go
+++ b/pkg/executions/pause.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/running.go
+++ b/pkg/executions/running.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/sendHeartbeat.go
+++ b/pkg/executions/sendHeartbeat.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/send_step.go
+++ b/pkg/executions/send_step.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/update.go
+++ b/pkg/executions/update.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/executions/update_step.go
+++ b/pkg/executions/update_step.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/flows/get_data.go
+++ b/pkg/flows/get_data.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/v1Flows/runner/config"
-	"github.com/v1Flows/runner/pkg/platform"
+	"github.com/JustLABv1/runner/config"
+	"github.com/JustLABv1/runner/pkg/platform"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,7 +1,7 @@
 package platform
 
 import (
-	"github.com/v1Flows/runner/config"
+	"github.com/JustLABv1/runner/config"
 )
 
 func GetPlatformConfig(cfg *config.Config) (string, string, string) {

--- a/pkg/plugins/cleanup.go
+++ b/pkg/plugins/cleanup.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/JustLABv1/runner/config"
 	log "github.com/sirupsen/logrus"
-	"github.com/v1Flows/runner/config"
 )
 
 func CleanupUnusedPlugins(pluginRepos []config.PluginConfig, pluginDir string) error {

--- a/pkg/plugins/download.go
+++ b/pkg/plugins/download.go
@@ -1,4 +1,3 @@
-// filepath: /Users/Justin.Neubert/projects/v1flows/v1Flows/runner/pkg/plugins/download.go
 package plugins
 
 import (
@@ -9,8 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/JustLABv1/runner/config"
 	log "github.com/sirupsen/logrus"
-	"github.com/v1Flows/runner/config"
 )
 
 // DownloadAndBuildPlugins downloads and builds plugins from GitHub
@@ -54,7 +53,7 @@ func DownloadPlugins(pluginRepos []config.PluginConfig, buildDir string, pluginD
 
 		// set default plugin url if not provided
 		if plugin.Url == "" {
-			plugin.Url = fmt.Sprintf("https://github.com/v1Flows/runner-plugins/releases/download/%s-%s/%s-%s-%s-%s", plugin.Name, plugin.Version, plugin.Name, plugin.Version, runtime.GOOS, runtime.GOARCH)
+			plugin.Url = fmt.Sprintf("https://github.com/JustLABv1/runner-plugins/releases/download/%s-%s/%s-%s-%s-%s", plugin.Name, plugin.Version, plugin.Name, plugin.Version, runtime.GOOS, runtime.GOARCH)
 		}
 
 		// Download the plugin

--- a/pkg/plugins/init.go
+++ b/pkg/plugins/init.go
@@ -1,4 +1,3 @@
-// filepath: /Users/Justin.Neubert/projects/v1flows/v1Flows/runner/pkg/plugins/init.go
 package plugins
 
 import (
@@ -8,10 +7,10 @@ import (
 	"time"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	log "github.com/sirupsen/logrus"
-	"github.com/v1Flows/runner/config"
 )
 
 var loadedPlugins = make(map[string]Plugin)

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -1,12 +1,11 @@
-// filepath: /Users/Justin.Neubert/projects/v1flows/v1Flows/runner/pkg/plugins/plugin.go
 package plugins
 
 import (
 	"net/rpc"
 
 	"github.com/JustLABv1/justflow/services/backend/pkg/models"
+	"github.com/JustLABv1/runner/config"
 	"github.com/hashicorp/go-plugin"
-	"github.com/v1Flows/runner/config"
 )
 
 // Plugin interface that all plugins must implement

--- a/pkg/steps/get_step.go
+++ b/pkg/steps/get_step.go
@@ -1,7 +1,7 @@
 package steps
 
 import (
-	"github.com/v1Flows/alertFlow/services/backend/pkg/models"
+	"github.com/JustLABv1/justflow/services/backend/pkg/models"
 )
 
 func GetStepByActionName(steps []models.ExecutionSteps, actionName string) models.ExecutionSteps {


### PR DESCRIPTION
…LABv1

- Updated README.md to reflect new plugin repository links.
- Changed import paths in main.go, config.go, and various internal packages to use JustLABv1.
- Modified CORS settings in main.go to allow justflow.app.
- Updated configuration keys in config.yaml to use justflow instead of exflow.
- Removed deprecated dependencies from go.mod and go.sum.
- Added cleanup functionality in a new cleanup.go file to manage workspace cleanup.
- Adjusted comments and function names to align with the new JustLABv1 branding.